### PR TITLE
Implement Hard Update Behaviour

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -13,10 +13,22 @@ You can also use the environment variables `GITUSERNAME` and `GITPASSWORD`.
 Or just delete the cloned repo and retry.
 This is used to push the commit for the dumps repo.
 
+When using the `HARD_UPDATE` flag, you can safely stop and resume the dump without losing progress. To restart the `HARD_UPDATE` manually, you need to clear the `./dumps` folder and delete `previous_run.lock`.
+
+### Environment Variables
 Use the environment variable `WEBSERVER=true` to run a webserver with that, bound on port PORT or by default 3000.
 The webserver will start indexing everytime you visit it. Only one job at at time.
 
-Use `NO_PUSH=TRUE` if you don't want to commit & push the results
+Use `NO_PUSH=TRUE` if you don't want to commit & push the results.
+
+Use `HARD_UPDATE=TRUE` to update existing games with 'null' achievements, instead of just pulling new entries. **This will take many hours due to the volume of requests.**
+
+### Validation
+
+Run `diff_dumps.js` and observe the output (you may want to `tee` or pipe to a file). A dump is valid if:
+1. No previous integer entries have been overwritten (e.g. achievement amount becomes null, games become junk, etc)
+1. No previous integer entries were removed (this implies something has gone wrong with the `index.js` script)
+1. No other spurious behavior is observed
 
 ## LICENSE
 

--- a/diff_dumps.js
+++ b/diff_dumps.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const run = require('child_process').execSync;
+
+const local_dump_path = "./dumps/app_list.json"
+const old_dump_dir = "./validation"
+const old_dump_path = "./validation/app_list.json"
+const master = "https://raw.githubusercontent.com/PaulCombal/SteamAppsListDumps/refs/heads/master/app_list.json"
+
+function diffDumps(){
+    console.log("Comparing dumps")
+    old_dump_string = fs.readFileSync(old_dump_path, encoding='UTF-8');
+    old_dump = JSON.parse(old_dump_string);
+    new_dump_string = fs.readFileSync(local_dump_path, encoding='UTF-8');
+    new_dump = JSON.parse(new_dump_string);
+    for (i = 0; i < old_dump.applist.apps.length; i++){
+        match = null;
+        for (j = 0; j < new_dump.applist.apps.length; j++){
+            // Find the entry in the new dump with the same appid
+            if (new_dump.applist.apps[j].appid == old_dump.applist.apps[i].appid){
+                match = j;
+                break;
+            }
+        }
+        if (match != null){
+            if (new_dump.applist.apps[match].achievements != old_dump.applist.apps[i].achievements){
+                if(old_dump.applist.apps[i].achievements != null && new_dump.applist.apps[i].achievements == null)
+                {
+                    console.error(`${old_dump.applist.apps[i].name}: ${old_dump.applist.apps[i].achievements} => ${new_dump.applist.apps[match].achievements}`);
+                } else {
+                    console.log(`${old_dump.applist.apps[i].name}: ${old_dump.applist.apps[i].achievements} => ${new_dump.applist.apps[match].achievements}`);
+                }
+                new_dump.applist.apps.splice(match, 1); // Remove the entry from the list
+            }
+        } else {
+            if(old_dump.applist.apps[i].achievements != null)
+            {
+                console.error(`${old_dump.applist.apps[i].name}: ${old_dump.applist.apps[i].achievements} => Removed`)
+            } else {
+                console.log(`${old_dump.applist.apps[i].name}: ${old_dump.applist.apps[i].achievements} => Removed`)
+            }
+        }
+    }
+    if(new_dump.applist.apps.length > 0){
+        for (j = 0; j < new_dump.applist.apps.length; j++){
+            // console.log(`${new_dump.applist.apps[j].name}: New entry => ${new_dump.applist.apps[match].achievements}`);
+        }
+    }
+}
+
+function getOldDump(){
+    console.log("Checking for previous dump");
+    if(!fs.existsSync(old_dump_path)){
+        console.log(`Previous dump not found, downloading from master (${master})`);
+        if (!fs.existsSync(old_dump_dir)) fs.mkdirSync(old_dump_dir);
+        wd = process.cwd();
+        process.chdir(old_dump_dir);
+        run(`curl -o app_list.json ${master}`);
+        process.chdir(wd);
+    } else {
+        console.log(`Found previous dump at ${old_dump_path}`);
+    }
+}
+
+getOldDump();
+diffDumps();


### PR DESCRIPTION
As discussed in PaulCombal/SamRewritten#166 by @romatthe, this PR had the primary goal of implementing the ability to update previous null entries. This does so non-destructively, only removing previous entries of `type == "game"` and `achievements == null`, rather than the previous POC that removed _all_ old entries. This also merges @romatthe's changes that greatly speed up the dumps, and implements some QoL features that are relevant.

- Merge @romatthe's payload reduction changes (b3f81669e6d5a8f4fd7f6c7461b0b11989771393, e822b3f5e00d25badeba3c45a2ccc611b55a5794, 83d8813c31b6441323cb1acbbadabc012f9b0afa, 88f8433762ee81a3c77671ff2402aba65508dcb2, c270c573ba55ff30dce0487e438fad870879de11)
- Prevent deletion of old games, and rename "FULL_UPDATE" to "HARD_UPDATE"; prevents losing games due to #1 (9209732b1be13d8e51db193c1d6bf2bc257dd3c3, 66c04c9d1f4d37e2ec31f239eeb11cab2da858f6)
- Implement saving every 10 batches, mitigating #5 (385212f55b2e86e26580038d1fad95d3347092cb, 90b1b14f0beb7ac58f3cf074bf9243d86c61c133)
- Create script to validate new dumps (ef5ddbe808933ca86504c3f92633993fe788250e, fd13394f00d92124d6a213bb8153e22c1e76614f)
- Documentation (ff2acac60b8fccf3ecbd48694c513f3a5892a746, eba409063ccd9920e293953670252bec5c92dccd, 886042ce4707d53582bce508efbe1c70b42370cf, b945091132216414091457c372ee3652cf4a9c09, 8a53b756f05e315eda4c7c747347af11c41827d8, 3671c06973eea63ae3332f0fa6a78e33c2bc493d)